### PR TITLE
Improve recursion during compile and fix some version is_possible checks

### DIFF
--- a/req_compile/repos/repository.py
+++ b/req_compile/repos/repository.py
@@ -92,7 +92,7 @@ def _get_platform_tags():
         tag = (
             ("linux_" + arch_tag),
             ("manylinux1_" + arch_tag),
-        )
+        )  # type: Tuple
         if is_manylinux2010_compatible():
             tag += ("manylinux2010_" + arch_tag,)
         if is_manylinux2014_compatible():

--- a/req_compile/versions.py
+++ b/req_compile/versions.py
@@ -5,6 +5,18 @@ PART_MAX = "999999999"
 
 def _offset_minor_version(version, offset, pos=2):
     parts = str(version).split(".")
+
+    for idx, part in enumerate(parts):
+        for char_idx, char in enumerate(part):
+            if not char.isdigit():
+                # If the entire thing starts with a character, drop it
+                # because it's a suffix
+                if char_idx == 0:
+                    parts = parts[:idx]
+                    break
+                parts[idx] = int(part[:char_idx])
+                break
+
     while len(parts) < 3:
         parts += ["0"]
 
@@ -34,6 +46,9 @@ def is_possible(req):  # pylint: disable=too-many-branches
     exact = None
     not_equal = []
     upper_bound = pkg_resources.parse_version("{max}.{max}.{max}".format(max=PART_MAX))
+    if len(req.specifier) == 1:
+        return True
+
     for spec in req.specifier:
         version = pkg_resources.parse_version(spec.version)
         if spec.operator == "==":

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="req-compile",
-    version="0.10.14post1",
+    version="0.10.15",
     author="Spencer Putt",
     author_email="sputt@alumni.iu.edu",
     description="Python requirements compiler",

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -14,6 +14,7 @@ parse_req = pkg_resources.Requirement.parse
         ("1.4.0", -1, "1.3.999999999"),
         ("1.4.0", 1, "1.4.1"),
         ("1.4.4.22", 1, "1.4.5.22"),
+        ("1.4.4b20", 1, "1.4.5"),
     ],
 )
 def test_offset_version(version, offset, result):
@@ -37,8 +38,12 @@ def test_equals_not_equals():
     assert not is_possible(parse_req("thing==1,!=1"))
 
 
-# def test_dev_version():
-#     assert is_possible(parse_req('thing<1.6,<2.0dev,>=1.5,>=1.6.0'))
+def test_dev_version():
+    assert not is_possible(parse_req('thing<1.6,<2.0dev,>=1.5,>=1.6.0'))
+
+
+def test_beta_version():
+    assert is_possible(parse_req('thing<20b0'))
 
 
 def test_no_constraints():


### PR DESCRIPTION
This pull requests marks nodes during solving "complete" earlier to reduce the number reentries into the compile_roots.  It also fixes a is_possible call for when versions include "dev" or "post"