### PR TITLE
Render `--find-links` into compiled outputs if provided in input files

### DIFF
--- a/req_compile/__main__.py
+++ b/req_compile/__main__.py
@@ -1,4 +1,5 @@
 """Forward the entrypoint to req_compile.cmdline to allow running via python -m req_compile"""
+
 import req_compile.cmdline
 
 if __name__ == "__main__":

--- a/req_compile/candidates.py
+++ b/req_compile/candidates.py
@@ -1,4 +1,5 @@
 """Dump candidates for requirements from repositories"""
+
 # pylint: disable=too-many-branches
 
 from __future__ import print_function

--- a/req_compile/compile.py
+++ b/req_compile/compile.py
@@ -90,7 +90,9 @@ def compile_roots(
             if depth > MAX_COMPILE_DEPTH:
                 raise ValueError("Recursion too deep")
             try:
-                for req in sorted(node.dependencies, key=lambda each_node: each_node.key):
+                for req in sorted(
+                    node.dependencies, key=lambda each_node: each_node.key
+                ):
                     if req in _path:
                         if options.allow_circular_dependencies:
                             logger.error(

--- a/req_compile/containers.py
+++ b/req_compile/containers.py
@@ -1,5 +1,6 @@
 import itertools
-from typing import Any, Iterable, Iterator, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 import packaging.requirements
 import packaging.version
@@ -101,7 +102,9 @@ class RequirementsFile(RequirementContainer):
         return "RequirementsFile({})".format(self.name)
 
     @classmethod
-    def from_file(cls, full_path: str, **kwargs: Any) -> "RequirementsFile":
+    def from_file(
+        cls, full_path: Union[str, Path], **kwargs: Any
+    ) -> "RequirementsFile":
         """Load requirements from a file and build a RequirementsFile
 
         Args:
@@ -111,8 +114,8 @@ class RequirementsFile(RequirementContainer):
             Additional arguments to forward to the class constructor
         """
         parameters: List[str] = []
-        reqs = reqs_from_files([full_path], parameters=parameters)
-        return cls(full_path, reqs, parameters=parameters, **kwargs)
+        reqs = reqs_from_files([str(full_path)], parameters=parameters)
+        return cls(str(full_path), reqs, parameters=parameters, **kwargs)
 
     def __str__(self) -> str:
         return self.name

--- a/req_compile/errors.py
+++ b/req_compile/errors.py
@@ -1,4 +1,5 @@
 """Errors describing problems that can occur when extracting metadata"""
+
 from typing import Any, Optional
 
 import packaging.version

--- a/req_compile/metadata/extractor.py
+++ b/req_compile/metadata/extractor.py
@@ -1,4 +1,5 @@
 """Extractors for Python distribution archive types"""
+
 from __future__ import annotations
 
 import abc

--- a/req_compile/metadata/patch.py
+++ b/req_compile/metadata/patch.py
@@ -1,4 +1,5 @@
 """Patching modules and objects"""
+
 import contextlib
 import sys
 import types

--- a/req_compile/metadata/pyproject.py
+++ b/req_compile/metadata/pyproject.py
@@ -1,4 +1,5 @@
 """PEP517 pyproject.toml support. One major restriction: build isolation is not supported"""
+
 import importlib
 import logging
 import os

--- a/req_compile/repos/findlinks.py
+++ b/req_compile/repos/findlinks.py
@@ -1,6 +1,7 @@
 import os
 from hashlib import sha256
-from typing import Any, List, Optional, Sequence, Tuple
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import pkg_resources
 from overrides import overrides
@@ -14,21 +15,63 @@ from req_compile.repos import Repository, RepositoryInitializationError
 from req_compile.repos.repository import Candidate
 
 
+def _relativize(from_path: Path, to_path: Path) -> Path:
+    """Compute the relative path from one location to another.
+
+    Unlike `pathlib.Path.relative_to`, this handles the case where a path
+    is trying to traverse up to a parent.
+
+    Args:
+        from_path: The starting location
+        to_path: The target location
+
+    Returns:
+        The relativized path
+    """
+    try:
+        return to_path.relative_to(from_path)
+    except ValueError:
+        # In the event from_path is not a parent of to_path, we will
+        # ignore the exception raised by `pathlib.Path.relative_to` and
+        # instead try to manually find a common parent so the path up
+        # to this location can be computed to then return the relative path.
+        pass
+
+    root = None
+    for parent in from_path.parents:
+        if parent in to_path.parents:
+            root = parent
+            break
+
+    if not root:
+        raise ValueError(f"{from_path} and {to_path} do not have a common parent")
+
+    to_root = Path("../" * len(from_path.relative_to(root).parents))
+
+    return to_root / to_path.relative_to(root)
+
+
 class FindLinksRepository(Repository):
     """
     A directory on the filesystem as a source of distributions.
     """
 
-    def __init__(self, path: str, allow_prerelease: Optional[bool] = None) -> None:
-        super(FindLinksRepository, self).__init__(
-            "findlinks", allow_prerelease=allow_prerelease
+    def __init__(
+        self,
+        path: Union[str, Path],
+        allow_prerelease: Optional[bool] = None,
+        relative_to: Optional[Union[str, Path]] = None,
+    ) -> None:
+        super().__init__("findlinks", allow_prerelease=allow_prerelease)
+        self.path = str(path)
+        self.relative_path = (
+            _relativize(Path(relative_to), Path(self.path)) if relative_to else None
         )
-        self.path = path
         self.links: List[Candidate] = []
         self._find_all_links()
 
     def __repr__(self) -> str:
-        return "--find-links {}".format(self.path)
+        return "--find-links {}".format(self.relative_path or self.path)
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -48,7 +91,10 @@ class FindLinksRepository(Repository):
         for filename in os.listdir(self.path):
             full_path = os.path.join(self.path, filename)
             candidate = req_compile.repos.repository.filename_to_candidate(
-                (self.path, full_path),
+                (
+                    str(self.relative_path) if self.relative_path else self.path,
+                    os.path.join(self.relative_path or self.path, filename),
+                ),
                 full_path,
             )
             if candidate is not None:

--- a/req_compile/repos/pypi.py
+++ b/req_compile/repos/pypi.py
@@ -1,4 +1,5 @@
 """Repository to handle pulling packages from online package indexes."""
+
 import enum
 import logging
 import os
@@ -11,7 +12,8 @@ import warnings
 from functools import lru_cache
 from hashlib import sha256
 from html.parser import HTMLParser
-from typing import Any, List, Optional, Sequence, Tuple
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import pkg_resources
 import requests
@@ -238,7 +240,7 @@ class PyPIRepository(Repository):
     def __init__(
         self,
         index_url: str,
-        wheeldir: str,
+        wheeldir: Union[str, Path],
         allow_prerelease: bool = False,
         retries: int = 3,
         index_type: IndexType = IndexType.INDEX_URL,

--- a/req_compile/repos/source.py
+++ b/req_compile/repos/source.py
@@ -1,4 +1,5 @@
 """Definition of source repository."""
+
 from __future__ import print_function
 
 import collections

--- a/tests/repos/test_findlinks.py
+++ b/tests/repos/test_findlinks.py
@@ -10,12 +10,28 @@ def test_find_links(tmpdir):
     wheeldir = str(tmpdir.mkdir("wheeldir"))
 
     source_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    subprocess.check_call(
+    subprocess.run(
         [sys.executable, "setup.py", "bdist_wheel", "--dist-dir", wheeldir],
         cwd=source_dir,
+        check=True,
     )
 
     repo = FindLinksRepository(wheeldir)
     candidates = list(repo.get_candidates(None))
     assert len(candidates) == 1
     assert candidates[0].name == "req_compile"
+
+
+def test_relative_to_repr(tmpdir):
+    (tmpdir / "wheeldir").mkdir()
+    assert str(FindLinksRepository(tmpdir)) == f"--find-links {tmpdir}"
+
+    assert (
+        str(FindLinksRepository(tmpdir / "wheeldir", relative_to=tmpdir))
+        == "--find-links wheeldir"
+    )
+
+    assert (
+        str(FindLinksRepository(tmpdir / "wheeldir", relative_to=tmpdir / "3rdparty"))
+        == "--find-links ../wheeldir"
+    )

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
-from io import StringIO
 import os
+from io import StringIO
 
 import pkg_resources
 import pytest


### PR DESCRIPTION
This change allows `--find-links` entries to be rendered whenever directives are rendered into compiled solutions.

Additionally, this change allows `FindLinksRepository` to be represented by a relative path should one be provided via the new `relative_to` constructor arg.