### PR TITLE
Allow `py_reqs_compiler` to write wheels for sdist dependencies

### DIFF
--- a/private/solution_tester.py
+++ b/private/solution_tester.py
@@ -7,7 +7,7 @@ import sys
 from rules_python.python.runfiles import Runfiles
 
 # pylint: disable-next=import-error
-from private.compiler import compile_main, parse_args, rlocation
+from private.compiler import compile_main, init_logging, parse_args, rlocation
 
 _WARNING = """\
 
@@ -34,6 +34,8 @@ def main() -> None:
         argv = args_file.read_text(encoding="utf-8").splitlines()
 
     args = parse_args(argv)
+
+    init_logging(args.verbose)
 
     try:
         compile_main(args, runfiles)


### PR DESCRIPTION
`py_reqs_compiler` can now accept a `--wheel-dir` argument where if set, will populate a directory with wheels in the event a solution cannot be compiled without relying on `sdist` releases. This can be useful in identifying and acquiring wheels for potential redistribution to maintain a binary-only dependency tree.