### PR TITLE
Enable windows CI

### DIFF
--- a/.github/release_notes.template
+++ b/.github/release_notes.template
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "req_compile",
     sha256 = "{sha256}",
-    urls = ["https://github.com/sputt/req-compile/releases/download/{version}/req_compile_src-v{version}.tar.gz"],
+    urls = ["https://github.com/sputt/req-compile/releases/download/{version}/rules_req_compile-v{version}.tar.gz"],
 )
 ```
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        platform: ["ubuntu-latest", "macos-latest"]
+        platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.platform }}
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        platform: ["ubuntu-latest", "macos-14"]
+        platform: ["ubuntu-latest", "macos-14", "windows-latest"]
     runs-on: ${{ matrix.platform }}
     name: bazel test ${{ matrix.platform }}
     steps:
@@ -80,6 +80,9 @@ jobs:
     - name: Run Tests
       run: |
         bazel test //...
+    - name: Perform compilation
+      run: |
+        bazel run //3rdparty:requirements_compiler "--" --upgrade
 
   bazel_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,8 @@ jobs:
           echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
       - name: Create release artifact
         run: |
-          tar -czf ${{ github.workspace }}/.github/req_compile_src.tar.gz --exclude=".git" --exclude=".github" --exclude="scripts" --exclude="dist" --exclude="build" -C ${{ github.workspace }} .
-          sha256="$(shasum --algorithm 256 ${{ github.workspace }}/.github/req_compile_src.tar.gz | awk '{ print $1 }')"
+          tar -czf ${{ github.workspace }}/.github/rules_req_compile.tar.gz --exclude=".git" --exclude=".github" --exclude="scripts" --exclude="dist" --exclude="build" -C ${{ github.workspace }} .
+          sha256="$(shasum --algorithm 256 ${{ github.workspace }}/.github/rules_req_compile.tar.gz | awk '{ print $1 }')"
           echo "ARCHIVE_SHA256=${sha256}" >> $GITHUB_ENV
       - name: Generate release notes
         run: |
@@ -58,8 +58,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.rules_release.outputs.upload_url }}
-          asset_name: req_compile_src-v${{ env.RELEASE_VERSION }}.tar.gz
-          asset_path: ${{ github.workspace }}/.github/req_compile_src.tar.gz
+          asset_name: rules_req_compile-v${{ env.RELEASE_VERSION }}.tar.gz
+          asset_path: ${{ github.workspace }}/.github/rules_req_compile.tar.gz
           asset_content_type: application/gzip
       - name: "Upload the wheel"
         uses: actions/upload-release-asset@v1

--- a/3rdparty/BUILD.bazel
+++ b/3rdparty/BUILD.bazel
@@ -9,6 +9,15 @@ filegroup(
     ],
 )
 
+alias(
+    name = "requirements_compiler",
+    actual = select({
+        "@platforms//os:linux": ":requirements_linux_311",
+        "@platforms//os:macos": ":requirements_macos_311",
+        "@platforms//os:windows": ":requirements_windows_311",
+    }),
+)
+
 py_reqs_compiler(
     name = "requirements_linux_311",
     requirements_in = ":requirements",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 """req-compile"""
 
 module(
-    name = "req_compile",
+    name = "rules_req_compile",
     version = "1.0.0rc13",
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,4 +1,4 @@
-workspace(name = "req_compile")
+workspace(name = "rules_req_compile")
 
 load("//:repositories.bzl", "req_compile_dependencies")
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -11,11 +11,11 @@ http_archive(
     urls = ["{see_release}"],
 )
 
-load("@req_compile//:repositories.bzl", "req_compile_dependencies")
+load("@rules_req_compile//:repositories.bzl", "req_compile_dependencies")
 
 req_compile_dependencies()
 
-load("@req_compile//:repositories_transitive.bzl", "req_compile_transitive_dependencies")
+load("@rules_req_compile//:repositories_transitive.bzl", "req_compile_transitive_dependencies")
 
 req_compile_transitive_dependencies()
 ```

--- a/private/compiler.bzl
+++ b/private/compiler.bzl
@@ -127,7 +127,7 @@ A Bazel rule for compiling python requirements for the current platform.
 
 
 ```python
-load("@req_compile//:defs.bzl", "py_reqs_compiler", "py_reqs_solution_test")
+load("@rules_req_compile//:defs.bzl", "py_reqs_compiler", "py_reqs_solution_test")
 
 filegroup(
     name = "requriements",
@@ -280,7 +280,7 @@ py_reqs_solution_test = rule(
 A Bazel test rule for ensuring the solution file for a `py_reqs_compiler` target satisifes the given requirements (`requirements_in`).
 
 ```python
-load("@req_compile//:defs.bzl", "py_reqs_compiler", "py_reqs_solution_test")
+load("@rules_req_compile//:defs.bzl", "py_reqs_compiler", "py_reqs_solution_test")
 
 py_reqs_compiler(
     name = "requirements.update",
@@ -298,7 +298,7 @@ py_reqs_solution_test(
 Alternatively, a test can be defined in isolation using just the requirements files:
 
 ```python
-load("@req_compile//:defs.bzl", "py_reqs_solution_test")
+load("@rules_req_compile//:defs.bzl", "py_reqs_solution_test")
 
 py_reqs_solution_test(
     name = "requirements_test",

--- a/private/reqs_repo.bzl
+++ b/private/reqs_repo.bzl
@@ -6,9 +6,9 @@ _CONSTRAINTS_BZL_TEMPLATE = """\
 \"\"\"Python constraints\"\"\"
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@req_compile//private:sdist_repo.bzl", "sdist_repository")
-load("@req_compile//private:utils.bzl", "sanitize_package_name")
-load("@req_compile//private:whl_repo.bzl", "whl_repository")
+load("@rules_req_compile//private:sdist_repo.bzl", "sdist_repository")
+load("@rules_req_compile//private:utils.bzl", "sanitize_package_name")
+load("@rules_req_compile//private:whl_repo.bzl", "whl_repository")
 
 def whl_repo_name(package):
     return "{repository_name}__" + sanitize_package_name(package)
@@ -117,7 +117,7 @@ def repositories():
 _RULES_PYTHON_COMPAT = """\
 \"\"\"A compatibility file with rules_python\"\"\"
 
-load("@req_compile//private:utils.bzl", "sanitize_package_name")
+load("@rules_req_compile//private:utils.bzl", "sanitize_package_name")
 load(
     ":defs.bzl",
     "repositories",
@@ -412,7 +412,7 @@ load(
 
 _INTERFACE_BZL_TEMPLATE = """\
 \"\"\"Python constraints\"\"\"
-load("@req_compile//private:utils.bzl", "sanitize_package_name")
+load("@rules_req_compile//private:utils.bzl", "sanitize_package_name")
 {loads}
 
 def whl_repo_name(package):
@@ -562,7 +562,7 @@ A rule for importing `requirements.txt` dependencies into Bazel.
 Those dependencies become available in a generated `defs.bzl` file.
 
 ```python
-load("@req_compile//:defs.bzl", "py_requirements_repository")
+load("@rules_req_compile//:defs.bzl", "py_requirements_repository")
 
 py_requirements_repository(
     name = "py_requirements",

--- a/private/tests/find_links/BUILD.find_links.bazel
+++ b/private/tests/find_links/BUILD.find_links.bazel
@@ -3,8 +3,8 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
     name = "find_links",
-    srcs = ["@req_compile//private/tests/find_links:find_links.py"],
-    main = "@req_compile//private/tests/find_links:find_links.py",
+    srcs = ["@rules_req_compile//private/tests/find_links:find_links.py"],
+    main = "@rules_req_compile//private/tests/find_links:find_links.py",
     deps = [
         requirement("pyspark"),
     ],

--- a/private/tests/version_test/version_test.py
+++ b/private/tests/version_test/version_test.py
@@ -32,7 +32,7 @@ class VersionTest(unittest.TestCase):
         if not runfiles:
             raise EnvironmentError("Failed to locate runfiles.")
 
-        version_bzl = rlocation(runfiles, "req_compile/version.bzl")
+        version_bzl = rlocation(runfiles, "rules_req_compile/version.bzl")
         bzl_version = re.findall(
             r'VERSION = "([\w\d\.]+)"',
             version_bzl.read_text(encoding="utf-8"),
@@ -40,9 +40,9 @@ class VersionTest(unittest.TestCase):
         )
         assert bzl_version, f"Failed to parse version from {version_bzl}"
 
-        module_bazel = rlocation(runfiles, "req_compile/MODULE.bazel")
+        module_bazel = rlocation(runfiles, "rules_req_compile/MODULE.bazel")
         module_version = re.findall(
-            r'module\(\n\s+name = "req_compile",\n\s+version = "([\d\w\.]+)",\n\)',
+            r'module\(\n\s+name = "rules_req_compile",\n\s+version = "([\d\w\.]+)",\n\)',
             module_bazel.read_text(encoding="utf-8"),
             re.MULTILINE,
         )

--- a/private/whl_repo.bzl
+++ b/private/whl_repo.bzl
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
 _BUILD_TEMPLATE = """\
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@req_compile//private:utils.bzl", "whl_repo_name")
+load("@rules_req_compile//private:utils.bzl", "whl_repo_name")
 load("@rules_python//python:defs.bzl", "py_library", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -201,7 +201,7 @@ def _whl_repository_impl(repository_ctx):
             whl_name = whl_file.basename
 
             whl_result = repository_ctx.download(
-                "file://{}".format(whl_file),
+                "file:///{}".format(whl_file),
                 output = whl_name,
                 sha256 = repository_ctx.attr.sha256,
             )
@@ -232,7 +232,7 @@ def _whl_repository_impl(repository_ctx):
             # wheel from the data file is ignored in the repository rule results but
             # __is__ used here to ensure there is no funny business when copying.
             repository_ctx.download(
-                "file://{}".format(whl_file),
+                "file:///{}".format(whl_file),
                 output = whl_name,
                 sha256 = expected_sha256,
             )

--- a/req_compile/repos/findlinks.py
+++ b/req_compile/repos/findlinks.py
@@ -27,9 +27,11 @@ class FindLinksRepository(Repository):
         relative_to: Optional[Union[str, Path]] = None,
     ) -> None:
         super().__init__("findlinks", allow_prerelease=allow_prerelease)
-        self.path = str(path)
+        self.path = Path(path).as_posix()
         self.relative_path = (
-            os.path.relpath(self.path, relative_to) if relative_to else None
+            Path(os.path.relpath(self.path, relative_to)).as_posix()
+            if relative_to
+            else None
         )
         self.links: List[Candidate] = []
         self._find_all_links()

--- a/tests/repos/test_findlinks.py
+++ b/tests/repos/test_findlinks.py
@@ -1,11 +1,12 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 from req_compile.repos.findlinks import FindLinksRepository
 
 
-def test_find_links(tmpdir):
+def test_find_links(tmpdir: Path) -> None:
     """Verify that a wheel for req-compile can be discovered properly"""
     wheeldir = str(tmpdir.mkdir("wheeldir"))
 
@@ -22,9 +23,10 @@ def test_find_links(tmpdir):
     assert candidates[0].name == "req_compile"
 
 
-def test_relative_to_repr(tmpdir):
+def test_relative_to_repr(tmpdir: Path) -> None:
     (tmpdir / "wheeldir").mkdir()
-    assert str(FindLinksRepository(tmpdir)) == f"--find-links {tmpdir}"
+    expected = Path(tmpdir).as_posix()
+    assert str(FindLinksRepository(tmpdir)) == f"--find-links {expected}"
 
     assert (
         str(FindLinksRepository(tmpdir / "wheeldir", relative_to=tmpdir))

--- a/tests/repos/test_solution.py
+++ b/tests/repos/test_solution.py
@@ -1,5 +1,6 @@
 import os
 from io import StringIO
+from pathlib import Path
 from textwrap import dedent
 
 import pkg_resources
@@ -184,6 +185,8 @@ def test_writing_repo_sources(mock_metadata, mock_pypi, tmp_path):
         mock_pypi,
     )
 
+    links_path = Path(tmp_path)
+
     buffer = StringIO()
     write_requirements_file(
         results,
@@ -191,7 +194,7 @@ def test_writing_repo_sources(mock_metadata, mock_pypi, tmp_path):
         repo=MultiRepository(
             [
                 mock_pypi,
-                FindLinksRepository(path=str(tmp_path)),
+                FindLinksRepository(path=links_path),
                 PyPIRepository(
                     index_url="https://index.com",
                     wheeldir=tmp_path,
@@ -211,7 +214,7 @@ def test_writing_repo_sources(mock_metadata, mock_pypi, tmp_path):
         f"""\
         --index-url https://index.com
         --extra-index-url https://extra.com
-        --find-links {tmp_path}
+        --find-links {links_path.as_posix()}
         """
     ).strip()
     assert header in buffer.getvalue()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
 # pylint: disable=protected-access
 import os
+import platform
 import sys
 from typing import Callable
 
@@ -53,7 +54,9 @@ def test_parse_flat_metadata_bizarre_extra():
     assert results.requires(extra="ssl:sys_platform=='win32'")[0].name == "wincertstore"
 
 
-def test_parse_flat_metadata_complex_marker(mock_py_version: Callable[[str], None]) -> None:
+def test_parse_flat_metadata_complex_marker(
+    mock_py_version: Callable[[str], None]
+) -> None:
     mock_py_version("3.7.12")
 
     results = req_compile.metadata.dist_info._parse_flat_metadata(
@@ -109,7 +112,7 @@ def test_compound(mock_targz):
     req_compile.metadata.metadata.extract_metadata(archive)
 
 
-sources = [
+_SOURCES = [
     ["svn-0.3.46", "svn", "0.3.46", ["python-dateutil>=2.2", "nose"]],
     ["dir-exists-1.0", "dir-exists", "1.0", ["msgpack-python"]],
     ["invalid-extra-2.1", "invalid-extra", "2.1", None],
@@ -159,24 +162,32 @@ sources = [
     ["file-input-1.0", "file-input", "1.0", None],
     ["capital-s-1.0", "capital-s", "1.0", []],
     ["dirsep-1.0", "dirsep", "1.0", []],
-    [
-        "newline-req-1.0",
-        "newline-req",
-        "1.0",
-        ["cfn_flip>=1.0.2", 'awacs>=0.8; extra == "policy"'],
-    ],
     ["version-writer-1.2", "version-writer", "1.2", []],
     ["tinyrpc-1.0.4", "tinyrpc", "1.0.4", ["six"]],
+    ["spec-loading-1.0", "spec-loading", "1.0", ["et_xmlfile", "jdcal"]],
 ]
-sources.append(["spec-loading-1.0", "spec-loading", "1.0", ["et_xmlfile", "jdcal"]])
 
 if sys.version_info[:2] < (3, 12):
     # Uses removed configparser methods.
-    sources.append(["ed-1.4", "ed", None, None])
+    _SOURCES.append(["ed-1.4", "ed", None, None])
+
+# TODO: This should be added to the common list above.
+# See https://github.com/sputt/req-compile/issues/53
+if platform.system() != "Windows":
+    _SOURCES.extend(
+        [
+            [
+                "newline-req-1.0",
+                "newline-req",
+                "1.0",
+                ["cfn_flip>=1.0.2", 'awacs>=0.8; extra == "policy"'],
+            ],
+        ]
+    )
 
 
 @pytest.mark.parametrize("archive_fixture", ["mock_targz", "mock_zip", "mock_fs"])
-@pytest.mark.parametrize("directory,name,version,reqs", sources)
+@pytest.mark.parametrize("directory,name,version,reqs", _SOURCES)
 def test_source_dist(
     archive_fixture, directory, name, version, reqs, mock_targz, mock_zip, mocker
 ):


### PR DESCRIPTION
This change disables a test and tracks re-enabling it via https://github.com/sputt/req-compile/issues/53 so that regression testing can be added for Windows.

Additionally, the Bazel workspace has been renamed from `req_compile` to `rules_req_compile` to de-conflict the python package names observed on Windows.