### PR TITLE
Update the format of the solution file to allow the source of extras …

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,5 +2,5 @@
 
 module(
     name = "rules_req_compile",
-    version = "1.0.0rc21",
+    version = "1.0.0rc22",
 )

--- a/req_compile/cmdline.py
+++ b/req_compile/cmdline.py
@@ -771,7 +771,8 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
         help="Constraints file or project directory to use as constraints.",
     )
     group.add_argument(
-        "-e", "--extra",
+        "-e",
+        "--extra",
         action="append",
         dest="extras",
         default=[],
@@ -779,7 +780,8 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
         help="Extras to apply automatically to source packages.",
     )
     group.add_argument(
-        "-P", "--upgrade-package",
+        "-P",
+        "--upgrade-package",
         action="append",
         dest="upgrade_packages",
         metavar="package_name",

--- a/req_compile/cmdline.py
+++ b/req_compile/cmdline.py
@@ -346,12 +346,12 @@ class ExplanationRender:
 
     def __str__(self):
         write_to = StringIO()
-        constraints = list(req_compile.dists.build_constraints(self.node))
+        constraints = req_compile.dists.build_explanation(self.node)
 
         if len(constraints) == 1:
             if self.multiline:
                 write_to.write("via ")
-            write_to.write(f"{constraints[0]}")
+            write_to.write(f"{next(iter(constraints))}")
         else:
             if self.multiline:
                 write_to.write("via\n")
@@ -763,14 +763,15 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
         "from stdin.",
     )
     group.add_argument(
-        "-c,--constraints",
+        "-c",
+        "--constraints",
         action="append",
         dest="constraints",
         metavar="constraints_file",
         help="Constraints file or project directory to use as constraints.",
     )
     group.add_argument(
-        "-e,--extra",
+        "-e", "--extra",
         action="append",
         dest="extras",
         default=[],
@@ -778,7 +779,7 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
         help="Extras to apply automatically to source packages.",
     )
     group.add_argument(
-        "-P,--upgrade-package",
+        "-P", "--upgrade-package",
         action="append",
         dest="upgrade_packages",
         metavar="package_name",
@@ -795,6 +796,12 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
         default=False,
         action="store_true",
         help="Remove distributions not satisfied via --source from the output.",
+    )
+    group.add_argument(
+        "--remove-constraints",
+        default=False,
+        action="store_true",
+        help="Remove constraints pins from the output.",
     )
     group.add_argument(
         "-p",
@@ -979,6 +986,7 @@ def compile_main(raw_args: Optional[Sequence[str]] = None) -> None:
             repo,
             extras=args.extras,
             constraint_reqs=constraint_reqs,
+            remove_constraints=args.remove_constraints,
             only_binary=args.only_binary,
         )
     except RepositoryInitializationError as ex:

--- a/req_compile/compile.py
+++ b/req_compile/compile.py
@@ -267,6 +267,7 @@ def perform_compile(
     input_reqs: Iterable[RequirementContainer],
     repo: Repository,
     constraint_reqs: Optional[Iterable[RequirementContainer]] = None,
+    remove_constraints: bool = False,
     extras: Optional[Iterable[str]] = None,
     allow_circular_dependencies: bool = True,
     only_binary: Optional[Set[NormName]] = None,
@@ -282,6 +283,9 @@ def perform_compile(
         repo: Repository to use as a source of Python packages.
         extras: Extras to apply automatically to source projects
         constraint_reqs: Constraints to use when compiling
+        remove_constraints: Whether to remove the constraints from the solution. By default,
+            constraints are added, so you can see why a requirement was pinned to a particular
+            version.
         allow_circular_dependencies: Whether to allow circular dependencies
         only_binary: Set of projects that should only consider binary distributions.
         max_downgrade: The maximum number of version downgrades that will be allowed for conflicts.
@@ -333,13 +337,15 @@ def perform_compile(
                 node, None, repo, results, options, max_downgrade=max_downgrade
             )
     except (NoCandidateException, MetadataError) as ex:
-        _add_constraints(all_pinned, constraint_reqs, results)
+        if not remove_constraints:
+            _add_constraints(all_pinned, constraint_reqs, results)
         ex.results = results
         raise
 
-    # Add the constraints in, so it will show up as a contributor in the results.
-    # The same is done in the exception block above
-    _add_constraints(all_pinned, constraint_reqs, results)
+    if not remove_constraints:
+        # Add the constraints in, so it will show up as a contributor in the results.
+        # The same is done in the exception block above
+        _add_constraints(all_pinned, constraint_reqs, results)
 
     return results, roots
 

--- a/tests/repos/requests_kerberos_solution.txt
+++ b/tests/repos/requests_kerberos_solution.txt
@@ -1,0 +1,13 @@
+certifi==2024.6.2          # requests (>=2017.4.17)
+cffi==1.15.1               # cryptography (>=1.12)
+charset-normalizer==3.3.2  # requests (<4,>=2)
+cryptography==42.0.8       # pyspnego, requests-kerberos (>=1.3)
+decorator==5.1.1           # gssapi
+gssapi==1.8.2              # pyspnego[kerberos] (>=1.6.0)
+idna==3.7                  # requests (<4,>=2.5)
+krb5==0.5.1                # pyspnego[kerberos] (>=0.3.0)
+pycparser==2.21            # cffi
+pyspnego==0.9.2            # requests-kerberos (>=0.9.2 [kerberos])
+requests==2.31.0           # requests-kerberos (>=1.1.0)
+requests-kerberos==0.14.0  # -
+urllib3==2.0.7             # requests (<3,>=1.21.1)

--- a/tests/repos/test_solution.py
+++ b/tests/repos/test_solution.py
@@ -177,7 +177,6 @@ def test_round_trip(
 
 
 def test_writing_repo_sources(mock_metadata, mock_pypi, tmp_path):
-
     mock_pypi.load_scenario("normal")
 
     results, nodes = req_compile.compile.perform_compile(
@@ -228,6 +227,17 @@ def test_load_additive_constraints():
     )
     constraints = solution_repo.solution["idna"].build_constraints()
     assert constraints == pkg_resources.Requirement.parse("idna<2.9,>=2.5")
+
+
+def test_load_extras() -> None:
+    """Test that if the correct extras are associated with the correct requirements."""
+    solution_repo = SolutionRepository(
+        os.path.join(os.path.dirname(__file__), "requests_kerberos_solution.txt")
+    )
+    assert solution_repo.solution["pyspnego"].extras == {"kerberos"}
+    assert [req for req in solution_repo.solution["requests-kerberos"].metadata.requires(
+        None
+    ) if req.project_name=="pyspnego"][0] == parse_requirement("pyspnego[kerberos]>=0.9.2")
 
 
 def test_load_extra_first():

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
 import os
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Set, Tuple
 from unittest import mock
 
 import pkg_resources
@@ -14,6 +14,7 @@ import req_compile.repos.repository
 import req_compile.utils
 from req_compile.compile import AllOnlyBinarySet
 from req_compile.containers import DistInfo, RequirementContainer
+from req_compile.dists import DependencyNode, DistributionCollection
 from req_compile.repos.multi import MultiRepository
 from req_compile.repos.repository import Candidate, Repository, filename_to_candidate
 from req_compile.repos.source import SourceRepository
@@ -29,10 +30,11 @@ def test_mock_pypi(mock_pypi):
     assert metadata.version == req_compile.utils.parse_version("1.0.0")
 
 
-def _real_outputs(results):
-    outputs = results[0].build(results[1])
-    outputs = sorted(outputs, key=lambda x: x.name)
-    return set(str(req) for req in outputs)
+def _real_outputs(results: Tuple[DistributionCollection, Set[DependencyNode]]):
+    return set(
+        "{}=={}".format(*node.metadata.to_definition(node.extras))
+        for node in results[0].visit_nodes(results[1])
+    )
 
 
 @fixture

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -2,7 +2,7 @@ import pkg_resources
 from pkg_resources import Requirement
 
 from req_compile.containers import DistInfo
-from req_compile.dists import DistributionCollection
+from req_compile.dists import DistributionCollection, build_explanation
 
 
 def test_unconstrained():
@@ -153,11 +153,14 @@ def test_repo_with_extra():
     )
     dists.add_dist(metadata_c, root_a, pkg_resources.Requirement.parse("a"))
 
-    lines = dists.generate_lines({root})
-    assert sorted(lines) == [
-        (("a[test]", "1.0.0", None), "root"),
-        (("b", "2.0.0", None), "a[test]"),
-        (("c", "2.0.0", None), "a"),
+    results = [
+        ("==".join(node.metadata.to_definition(node.extras)), build_explanation(node))
+        for node in dists.visit_nodes({root})
+    ]
+    assert sorted(results) == [
+        ("a[test]==1.0.0", ["root ([test])"]),
+        ("b==2.0.0", ["a[test]"]),
+        ("c==2.0.0", ["a"]),
     ]
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 
+from req_compile.config import read_pip_default_index
+
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 
 
@@ -45,7 +47,7 @@ def test_compile_req_compile(tmp_path):
             "-m",
             "req_compile",
             "-i",
-            "https://pypi.org/simple",
+            read_pip_default_index() or "https://pypi.org/simple",
             ".",
             "--wheel-dir",
             str(tmp_path),

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """req-compile version"""
 
-VERSION = "1.0.0rc21"
+VERSION = "1.0.0rc22"


### PR DESCRIPTION
…to be preserved.

A new format in the explanation clause provides a [] delimited extra that supplied the requirement. For example, if cryptography was provided by the "security" extra from the requests library and your project required requests[security], the lines would now appear as:

    myproject==1.0
    requests==2.0  # myproject (>=2 [security])
    cryptography==1.0.0  # requests[security] (>=1)

The extra marker is required to build the dependency tree back exactly.

This fixes #79