### PR TITLE
Added `patch` to `py_package_annotation` for `whl_repository` repos.

### DIFF
--- a/private/annotation.bzl
+++ b/private/annotation.bzl
@@ -28,7 +28,8 @@ def py_package_annotation(
         data_exclude_glob = [],
         srcs_exclude_glob = [],
         deps = [],
-        deps_excludes = []):
+        deps_excludes = [],
+        patches = []):
     """Annotations to apply to the BUILD file content from package generated from a `pip_repository` rule.
 
     [cf]: https://github.com/bazelbuild/bazel-skylib/blob/main/docs/copy_file_doc.md
@@ -51,6 +52,7 @@ def py_package_annotation(
         deps (list, optional): A list of dependencies to include to the package. Can be other packages or labels.
         deps_excludes (list, optional): A list of packages to exclude from the package. (In cases where a package
             has circular dependencies).
+        patches (list, optional): A list of patch files to apply to the wheel.
 
     Returns:
         str: A json encoded string of the provided content.
@@ -64,17 +66,23 @@ def py_package_annotation(
     if additive_build_content:
         additive_content += additive_build_content
 
+    str_patches = []
+    for patch in patches:
+        _assert_absolute(patch)
+        str_patches.append(str(patch))
+
     return json.encode(struct(
         additive_build_file = str(additive_build_file) if additive_build_file else None,
         additive_build_file_content = additive_content,
-        copy_srcs = copy_srcs,
-        copy_files = copy_files,
         copy_executables = copy_executables,
+        copy_files = copy_files,
+        copy_srcs = copy_srcs,
         data = data,
         data_exclude_glob = data_exclude_glob,
-        srcs_exclude_glob = srcs_exclude_glob,
         deps = deps,
         deps_excludes = deps_excludes,
+        patches = str_patches,
+        srcs_exclude_glob = srcs_exclude_glob,
     ))
 
 def deserialize_package_annotation(content):
@@ -115,6 +123,7 @@ def deserialize_package_annotation(content):
         srcs_exclude_glob = data.get("srcs_exclude_glob", []),
         deps = data.get("deps", []),
         deps_excludes = data.get("deps_excludes", []),
+        patches = data.get("patches", []),
     )
 
 PyPackageAnnotatedTargetInfo = provider(

--- a/private/tests/annotations/annotations.py
+++ b/private/tests/annotations/annotations.py
@@ -1,10 +1,11 @@
-"""The sdist integration test"""
+"""The annotations integration test"""
 
 import platform
 import unittest
 from pathlib import Path
 
 from numpy import __version__ as numpy_version  # pylint: disable=import-error
+from numpy.__config__ import req_comple_annotation  # pylint: disable=import-error
 from rules_python.python.runfiles import Runfiles  # pylint: disable=import-error
 from sphinx import __version__ as sphinx_version  # pylint: disable=import-error
 
@@ -15,6 +16,9 @@ class IntegrationTest(unittest.TestCase):
 
     def test_sphinx_version(self) -> None:
         assert sphinx_version == "7.2.6"
+
+    def test_patches_annotation(self) -> None:
+        assert req_comple_annotation == "req-compile"
 
     def test_copy_annotations(self) -> None:
         runfiles = Runfiles.Create()

--- a/private/tests/annotations/annotations_test_deps.bzl
+++ b/private/tests/annotations/annotations_test_deps.bzl
@@ -47,6 +47,9 @@ def req_compile_test_annotations_deps():
                 copy_executables = {
                     "site-packages/numpy/testing/setup.py": "site-packages/numpy/testing/setup.copy.py",
                 },
+                patches = [
+                    Label("//private/tests/annotations:numpy.patch"),
+                ],
             ),
             # Sphinx is known to have a circular dependency. The annotations here solve for that.
             "sphinxcontrib-applehelp": package_annotation(

--- a/private/tests/annotations/numpy.patch
+++ b/private/tests/annotations/numpy.patch
@@ -1,0 +1,13 @@
+diff --git a/site-packages/numpy/__config__.py b/site-packages/numpy/__config__.py
+index 6f09de3..62168b4 100644
+--- a/site-packages/numpy/__config__.py
++++ b/site-packages/numpy/__config__.py
+@@ -9,7 +9,7 @@ from numpy.core._multiarray_umath import (
+ 
+ __all__ = ["show"]
+ _built_with_meson = True
+-
++req_comple_annotation = "req-compile"
+ 
+ class DisplayModes(Enum):
+     stdout = "stdout"

--- a/private/whl_repo.bzl
+++ b/private/whl_repo.bzl
@@ -266,13 +266,17 @@ def _whl_repository_impl(repository_ctx):
     )
     repository_ctx.delete(whl_name + ".zip")
 
-    for patch in repository_ctx.attr.patches:
+    annotations = deserialize_package_annotation(repository_ctx.attr.annotations)
+
+    patches = repository_ctx.attr.patches + [
+        repository_ctx.path(Label(patch))
+        for patch in annotations.patches
+    ]
+    for patch in patches:
         repository_ctx.patch(
             patch,
             strip = 1,
         )
-
-    annotations = deserialize_package_annotation(repository_ctx.attr.annotations)
 
     # Parse deps from annotations
     negative_deps = [


### PR DESCRIPTION
This change allows patches for wheels to be defined via `py_package_annotation`. This can be useful when for applying code changes to a requirement common to all platforms without requiring users to maintain a separate pin of an explicit `whl_repository`.