### PR TITLE
Support Labels being passed to `annotation.deps`

### DIFF
--- a/private/annotation.bzl
+++ b/private/annotation.bzl
@@ -71,6 +71,14 @@ def py_package_annotation(
         _assert_absolute(patch)
         str_patches.append(str(patch))
 
+    # Ensure deps can be json seralized
+    str_deps = []
+    for dep in deps:
+        if type(dep) == "Label":
+            str_deps.append(str(dep))
+        else:
+            str_deps.append(dep)
+
     return json.encode(struct(
         additive_build_file = str(additive_build_file) if additive_build_file else None,
         additive_build_file_content = additive_content,
@@ -79,7 +87,7 @@ def py_package_annotation(
         copy_srcs = copy_srcs,
         data = data,
         data_exclude_glob = data_exclude_glob,
-        deps = deps,
+        deps = str_deps,
         deps_excludes = deps_excludes,
         patches = str_patches,
         srcs_exclude_glob = srcs_exclude_glob,

--- a/private/tests/annotations/annotations_test_deps.bzl
+++ b/private/tests/annotations/annotations_test_deps.bzl
@@ -50,6 +50,10 @@ def req_compile_test_annotations_deps():
                 patches = [
                     Label("//private/tests/annotations:numpy.patch"),
                 ],
+                deps = [
+                    # Show that label dependencies can be added.
+                    Label("@rules_python//python/runfiles"),
+                ],
             ),
             # Sphinx is known to have a circular dependency. The annotations here solve for that.
             "sphinxcontrib-applehelp": package_annotation(


### PR DESCRIPTION
Previously if an annotation was applied to add a Bazel dependency the plumbing would lead to an invalid dependency. This change fixes this issue and now allows Bazel targets to be added to package dependencies.