### PR TITLE
Mark test `*.html` files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Git attributes
+
+tests/**/*.html linguist-generated


### PR DESCRIPTION
This way Github doesn't report 43% of the repo is HTML